### PR TITLE
fix(loadChunk): skip three includes with mixed syntax

### DIFF
--- a/src/loadShaders.ts
+++ b/src/loadShaders.ts
@@ -37,13 +37,13 @@ function removeSourceComments (source: string): string {
  * @returns {string} Shader's source code without external chunks
  */
 function loadChunk (source: string, directory: string, extension: string): string {
-  const include = /#include(\s+([^\s<>]+))/;
+  const include = /#include(\s+([^\s<>]+));?/gi;
   source = removeSourceComments(source);
 
   if (include.test(source)) {
     const currentDirectory = directory;
 
-    source = source.replace(/#include (.*);?/gi, (_, chunkPath: string): string => {
+    source = source.replace(include, (_, chunkPath: string): string => {
       chunkPath = chunkPath.trim().replace(/^(?:"|')?|(?:"|')?;?$/gi, '');
 
       const directoryIndex = chunkPath.lastIndexOf('/');


### PR DESCRIPTION
When using this plugin with three's proprietary shader-chunks syntax and plugin-compatible file includes, the plugin will incorrectly try to include three's chunks as files.

```glsl
// Source gets inlined
#include path/to/shader.glsl

// This should stay unmangled for three
#include <three_shader_chunk> 
```

This PR keeps the chunk include behavior consistent with prior filtering that should harden this area.