### PR TITLE
feat: generate sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@rollup/pluginutils": "^4.1.2",
+    "magic-string": "^0.26.1",
     "tslib": "^2.3.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -152,6 +152,13 @@ is-core-module@^2.8.0:
   dependencies:
     has "^1.0.3"
 
+magic-string@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.26.1.tgz#ba9b651354fa9512474199acecf9c6dbe93f97fd"
+  integrity sha512-ndThHmvgtieXe8J/VGPjG+Apu7v7ItcD5mhEIvOscWjPF/ccOiLxHaSuCAS2G+3x4GKsAbT8u7zdyamupui8Tg==
+  dependencies:
+    sourcemap-codec "^1.4.8"
+
 nanoid@^3.1.30:
   version "3.1.32"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.32.tgz#8f96069e6239cc0a9ae8c0d3b41a3b4933a88c0a"
@@ -201,6 +208,11 @@ source-map-js@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.1.tgz#a1741c131e3c77d048252adfa24e23b908670caf"
   integrity sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==
+
+sourcemap-codec@^1.4.8:
+  version "1.4.8"
+  resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 supports-preserve-symlinks-flag@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Generates sourcemaps when [`config.build.sourcemap`](https://vitejs.dev/config/#build-sourcemap) is configured to do so via https://npmjs.com/magic-string and [`configResolved`](https://vitejs.dev/guide/api-plugin.html#configresolved).

To test, enable/disable sourcemap:

```js
// vite.config.js
import vite from 'vite';

export default vite.defineConfig({
  build: {
    sourcemap: true
  }
);
```

Build and analyze:

```bash
npx vite build
npx source-map-explorer dist/assets/*.js
```