### PR TITLE
chore: vite 4 is out

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "test": "vite"
   },
   "peerDependencies": {
-    "vite": "^3.0.0"
+    "vite": "^3.0.0 || ^4.0.0"
   },
   "dependencies": {
     "@rollup/pluginutils": "^5.0.2"


### PR DESCRIPTION
since few days, vite 4 is out. Projects using `vite@4`, and `vite-plugin-gsl` will encounter this peerDep issue:

```
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: vite-plugin-glsl@0.5.4
npm ERR! Found: vite@4.0.0
npm ERR! node_modules/vite
npm ERR!   dev vite@"^4.0.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer vite@"^3.0.0" from vite-plugin-glsl@0.5.4
npm ERR! node_modules/vite-plugin-glsl
npm ERR!   dev vite-plugin-glsl@"^0.5.4" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: vite@3.2.5
npm ERR! node_modules/vite
npm ERR!   peer vite@"^3.0.0" from vite-plugin-glsl@0.5.4
npm ERR!   node_modules/vite-plugin-glsl
npm ERR!     dev vite-plugin-glsl@"^0.5.4" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! See /home/runner/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2022-12-10T10_35_09_491Z-debug-0.log
Error: Process completed with exit code 1.
```