### PR TITLE
Add included chunks to moduleGraph

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "./src/index.d.ts",
   "module": "./src/index.js",
   "main": "./src/index.js",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "private": false,
   "license": "MIT",
   "type": "module",

--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
  * @module vite-plugin-glsl
  * @author Ustym Ukhman <ustym.ukhman@gmail.com>
  * @description Import, inline (and compress) GLSL shader files
- * @version 1.1.1
+ * @version 1.1.2
  * @license MIT
  */
 
@@ -54,6 +54,7 @@ export default function ({
   } = {}
 ) {
   let config = undefined;
+  let server;
   const filter = createFilter(include, exclude);
   const prod = process.env.NODE_ENV === 'production';
 
@@ -61,10 +62,8 @@ export default function ({
     enforce: 'pre',
     name: 'vite-plugin-glsl',
 
-    configureServer (server) {
-      watch && server.watcher.on('change', shader =>
-        filter(shader) && server.restart()
-      );
+    configureServer(_server) {
+      server = _server;
     },
 
     configResolved (resolvedConfig) {
@@ -72,13 +71,53 @@ export default function ({
     },
 
     async transform (source, shader) {
-      if (filter(shader)) return await transformWithEsbuild(
-        loadShader(source, shader, {
-          warnDuplicatedImports,
-          defaultExtension,
-          compress,
-          root
-        }),
+      if (!filter(shader)) return;
+
+      const result = loadShader(source, shader, {
+        warnDuplicatedImports,
+        defaultExtension,
+        compress,
+        root
+      });
+
+      // use shader path as id
+      const id = shader;
+      // flatten all recursive dependencies 
+      const deps = Array.from(result.deps.values()).flat();
+
+      // dev
+      if (server) {
+        // server only logic for handling GLSL #include dependency hmr
+        const { moduleGraph } = server
+        const thisModule = moduleGraph.getModuleById(id)
+        if (thisModule) {
+          const isSelfAccepting = true;
+          if (deps) {
+            // record deps in the module graph so edits to the #include file
+            // can trigger main import to hot update
+            const depModules = new Set();
+            for (const file of deps) {
+              depModules.add(moduleGraph.createFileOnlyEntry(file));
+            }
+            moduleGraph.updateModuleInfo(
+              thisModule,
+              depModules,
+              null,
+              // The root proxy module is self-accepting and should not
+              // have an explicit accept list
+              new Set(),
+              null,
+              isSelfAccepting,
+              false,
+            )
+          } else {
+            thisModule.isSelfAccepting = isSelfAccepting
+          }
+        }
+      }
+
+      return await transformWithEsbuild(
+        result.code,
         shader, {
           sourcemap: config.build.sourcemap && 'external',
           loader: 'text', format: 'esm',

--- a/src/loadShader.d.ts
+++ b/src/loadShader.d.ts
@@ -1,4 +1,4 @@
-import type { LoadingOptions } from './types.d';
+import type { LoadingOptions, LoadingResult } from './types.d';
 
 /**
  * @function
@@ -15,6 +15,6 @@ import type { LoadingOptions } from './types.d';
  *  - whether (and how) to compress output shader code
  *  - directory for chunk imports from root
  * 
- * @returns {string} Shader file with included chunks
+ * @returns {LoadingResult} Output processed shader and dependencies
  */
-export default function (source: string, shader: string, options: LoadingOptions): string;
+export default function (source: string, shader: string, options: LoadingOptions): LoadingResult;

--- a/src/loadShader.js
+++ b/src/loadShader.js
@@ -302,7 +302,7 @@ function loadChunks (source, path, extension, warn, root) {
  *  - whether (and how) to compress output shader code
  *  - directory for chunk imports from root
  * 
- * @returns {string} Shader file with included chunks
+ * @returns {LoadingResult} Output processed shader and dependencies
  */
 export default function (source, shader, options) {
   const { compress, defaultExtension, warnDuplicatedImports, root } = options;
@@ -314,7 +314,11 @@ export default function (source, shader, options) {
     warnDuplicatedImports, root
   );
 
-  return !compress ? output
+  const code = !compress ? output
     : typeof compress === 'function'
     ? compress(output) : comressShader(output);
+  
+  const deps = dependentChunks;
+
+  return { code, deps };
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -40,6 +40,19 @@ export type LoadingOptions = {
 };
 
 /**
+ * @typedef {Object}
+ * @name LoadingResult
+ * @description Output of the loaded and processed shader
+ * 
+ * @property {string}                 code   Shader file with included chunks
+ * @property {Map<string, string[]>}  deps   Map of shaders that import other chunks
+ */
+export type LoadingResult = {
+  code: string;
+  deps?: Record<string, string[]>;
+};
+
+/**
  * @since 0.2.0
  * @typedef {Object}
  * @name PluginOptions


### PR DESCRIPTION
The intention behind this PR is to avoid a `server.restart()` when a shader file is updated - as discussed on https://github.com/UstymUkhman/vite-plugin-glsl/issues/31

The implementation proposed here follows Vite's [plugin/css](https://github.com/vitejs/vite/blob/73afe6d4db0dea6a1f1745e6742b5678ae63ec46/packages/vite/src/node/plugins/css.ts#L255).

Here's an online example:
https://stackblitz.com/edit/vitejs-vite-7cujfh?file=glsl%2Finclude-B.glsl
