### PR TITLE
Add support for Vite 5.x.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "test": "vite"
   },
   "peerDependencies": {
-    "vite": "^3.0.0 || ^4.0.0"
+    "vite": "^3.0.0 || ^4.0.0 || ^5.0.0"
   },
   "dependencies": {
     "@rollup/pluginutils": "^5.0.2"


### PR DESCRIPTION
This change modifies the peer dependencies for this project to support the recent breaking version change to Vite JS due to dropping node support prior to 18.