### PR TITLE
Add vite 7.0.0 to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "test": "vite"
   },
   "peerDependencies": {
-    "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0"
+    "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
   },
   "dependencies": {
     "@rollup/pluginutils": "^5.1.4"


### PR DESCRIPTION
vite 7.0.0 has been released and we need to update the plugin dependencies. Since 7.0.0 is a drop-in replacement where already deprecated features are just being removed it should work without changing anything (https://vite.dev/blog/announcing-vite7.html#migrating-to-vite-7)