### PR TITLE
Fix old Vite versions support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,7 +55,7 @@ export default async function ({
       });
     }
 
-    if (+Vite.version.replaceAll('.', '') < 630) {
+    if (+Vite.version.replaceAll('.', '') < 6300) {
       try {
         filter = (await import('@rollup/pluginutils'))
           .createFilter(include, exclude);


### PR DESCRIPTION
I have the following versions:
Vite: 5.4.20
vite-plugin-glsl: 1.5.3

I found that the check at 
https://github.com/UstymUkhman/vite-plugin-glsl/blob/60a4f591da1a54fc54b897f7ccaab78f8c60cf92/src/index.js#L58
returns 5420 < 630 on versions like mine, skipping the entire import (and ultimately making the plugin handle .js files as .glsl).
This is a tentative fix, albeit not a solid one. I tried running it with this fix and it seems working!