### PR TITLE
Strip all block comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,3 +251,9 @@ vec3 randVec3 (const in vec2 uv) {
   );
 }
 ```
+
+
+## Testing ##
+
+- `npm test`: manual browser check: open the dev server and inspect the transformed shader source text printed on the page.
+- `npm run test:automated`: runs `test/automated` regression tests.

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "webgpu-shaders"
   ],
   "scripts": {
-    "test": "vite"
+    "test": "vite",
+    "test:automated": "node --test test/automated"
   },
   "peerDependencies": {
     "vite": ">= 3.x",

--- a/src/index.js
+++ b/src/index.js
@@ -102,7 +102,8 @@ export default async function ({
           .flat().forEach(chunk => this.addWatchFile(chunk));
 
         return await (oxc
-          ? Vite.transformWithOxc(`export default \`${outputShader}\``, shader, { sourcemap })
+          // Use JSON.stringify to escape special characters like ` or ${} in outputShader
+          ? Vite.transformWithOxc(`export default ${JSON.stringify(outputShader)};`, shader, { sourcemap })
           : Vite.transformWithEsbuild(outputShader, shader, {
             sourcemap: sourcemap && 'external',
             loader: 'text', format: 'esm',

--- a/src/loadShader.js
+++ b/src/loadShader.js
@@ -110,27 +110,45 @@ function checkDuplicatedImports (path) {
  * @param {string}  source  Shader's source code
  * @param {RegExp}  pattern RegExp to import chunks
  * @param {boolean} triple  Remove triple slash comments
+ * @param {string}  shader  Shader's absolute path
  * 
  * @returns {string} Shader's source code without comments
  */
-function removeSourceComments (source, pattern, triple = false) {
-  while (source.includes('/*') && source.includes('*/')) {
-    source = source.slice(0, source.indexOf('/*')) +
-    source.slice(source.indexOf('*/') + 2, source.length);
-  }
+function removeSourceComments (source, pattern, triple = false, shader) {
+  let output = '';
+  let index = 0;
 
-  const lines = source.split('\n');
+  while (index < source.length) {
+    if (source.startsWith('//', index)) {
+      // Single line comment
+      const nextLine = source.indexOf('\n', index);
+      const lineEnd = nextLine === -1 ? source.length : nextLine;
+      const comment = source.slice(index, lineEnd);
+      const containsImport = comment.search(pattern) !== -1;
 
-  for (let l = lines.length; l--; ) {
-    const index = lines[l].indexOf('//');
+      if (comment.startsWith('///') && !containsImport && !triple) {
+        // Triple backslash comments are retained by default
+        output += comment;
+      }
 
-    if (index > -1) {
-      if (lines[l][index + 2] === '/' && !pattern.test(lines[l]) && !triple) continue;
-      lines[l] = lines[l].slice(0, index);
+      index = lineEnd;
+    } else if (source.startsWith('/*', index)) {
+      // Block comment
+      const commentEnd = source.indexOf('*/', index + 2);
+
+      if (commentEnd === -1) {
+        throw new Error(`Unterminated block comment in "${shader}".`);
+      }
+
+      index = commentEnd + 2;
+    } else {
+      // No comment here
+      output += source[index];
+      index++;
     }
   }
 
-  return lines.join('\n');
+  return output;
 }
 
 /**
@@ -265,7 +283,7 @@ function loadChunks (source, path, pattern, options) {
   if (recursion) return recursiveChunk;
   else if (recursion === null) return '';
 
-  source = removeSourceComments(source, pattern);
+  source = removeSourceComments(source, pattern, false, unixPath);
   let directory = dirname(unixPath);
   allChunks.add(chunkPath);
 
@@ -349,7 +367,7 @@ export default async function (source, shader, options) {
   let outputShader = loadChunks(source, shader, pattern, options);
 
   options.minify && (outputShader = minifyShader(
-    removeSourceComments(outputShader, pattern, true))
+    removeSourceComments(outputShader, pattern, true, shader))
   );
 
   outputShader = await options.onComplete?.(outputShader, shader) ?? outputShader;

--- a/src/loadShader.js
+++ b/src/loadShader.js
@@ -114,7 +114,7 @@ function checkDuplicatedImports (path) {
  * @returns {string} Shader's source code without comments
  */
 function removeSourceComments (source, pattern, triple = false) {
-  if (source.includes('/*') && source.includes('*/')) {
+  while (source.includes('/*') && source.includes('*/')) {
     source = source.slice(0, source.indexOf('/*')) +
     source.slice(source.indexOf('*/') + 2, source.length);
   }

--- a/test/automated/comment-delimiters.test.js
+++ b/test/automated/comment-delimiters.test.js
@@ -26,6 +26,26 @@ test('loadShader ignores block-comment delimiters inside line comments', async (
   assert.equal(outputShader, 'void main() {}');
 });
 
+// Similarly, line comments must be interpreted in block comment context
+test('loadShader ignores line comments inside block comments', async () => {
+  const source = [
+    '/* commentedOut(code) // explanation of dead code */',
+    'void main() {}'
+  ].join('\n');
+
+  const { outputShader } = await loadShader(source, '/virtual/shader.frag', {
+    removeDuplicatedImports: false,
+    warnDuplicatedImports: true,
+    defaultExtension: 'glsl',
+    importKeywords: ['#include'],
+    onComplete: undefined,
+    minify: false,
+    root: '/'
+  });
+
+  assert.equal(outputShader, 'void main() {}');
+});
+
 test('loadShader rejects unterminated block comments', async () => {
   const source = [
     'precision highp float;',

--- a/test/automated/comment-delimiters.test.js
+++ b/test/automated/comment-delimiters.test.js
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import loadShader from '../../src/loadShader.js';
+
+// Comment delimiters must be interpreted in lexical context. In particular,
+// a */ inside a line comment must not close a later block comment.
+test('loadShader ignores block-comment delimiters inside line comments', async () => {
+  const source = [
+    '// */',
+    '',
+    '/* block comment */',
+    'void main() {}'
+  ].join('\n');
+
+  const { outputShader } = await loadShader(source, '/virtual/shader.frag', {
+    removeDuplicatedImports: false,
+    warnDuplicatedImports: true,
+    defaultExtension: 'glsl',
+    importKeywords: ['#include'],
+    onComplete: undefined,
+    minify: false,
+    root: '/'
+  });
+
+  assert.equal(outputShader, 'void main() {}');
+});

--- a/test/automated/comment-delimiters.test.js
+++ b/test/automated/comment-delimiters.test.js
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { fileURLToPath } from 'node:url';
 import loadShader from '../../src/loadShader.js';
 
 // Comment delimiters must be interpreted in lexical context. In particular,
@@ -23,4 +24,46 @@ test('loadShader ignores block-comment delimiters inside line comments', async (
   });
 
   assert.equal(outputShader, 'void main() {}');
+});
+
+test('loadShader rejects unterminated block comments', async () => {
+  const source = [
+    'precision highp float;',
+    '',
+    '/* unterminated comment',
+    'void main() {}'
+  ].join('\n');
+
+  await assert.rejects(loadShader(source, '/virtual/shader.frag', {
+    removeDuplicatedImports: false,
+    warnDuplicatedImports: true,
+    defaultExtension: 'glsl',
+    importKeywords: ['#include'],
+    onComplete: undefined,
+    minify: false,
+    root: '/'
+  }));
+});
+
+test('loadShader only removes triple-slash comments containing imports', async () => {
+  const source = [
+    '#include chunk3.frag /// preserved documentation',
+    '/// #include missing.frag',
+    'void main() {}'
+  ].join('\n');
+  // Provide a properly formatted path so that chunk3.frag will resolve correctly
+  const shader = fileURLToPath(new URL('../glsl/main.frag', import.meta.url));
+
+  const { outputShader } = await loadShader(source, shader, {
+    removeDuplicatedImports: false,
+    warnDuplicatedImports: true,
+    defaultExtension: 'glsl',
+    importKeywords: ['#include'],
+    onComplete: undefined,
+    minify: false,
+    root: '/'
+  });
+
+  assert.match(outputShader, /\/\/\/ preserved documentation/);
+  assert.doesNotMatch(outputShader, /missing\.frag/);
 });

--- a/test/automated/comment-stripping.test.js
+++ b/test/automated/comment-stripping.test.js
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import loadShader from '../../src/loadShader.js';
+
+/**
+ * All block comments must be stripped from shader output, not just the
+ * first one. Any that leak through can carry backticks, breaking the
+ * `transformWithOxc` path (see oxc-backtick.test.js), and can also hide
+ * `#include` directives or code from later chunk-import parsing.
+ */
+test('loadShader removes every block comment, not just the first one', async () => {
+  const source = [
+    'precision highp float;',
+    '',
+    '/**',
+    ' * First comment block.',
+    ' */',
+    'uniform float foo;',
+    '',
+    '/**',
+    ' * Second comment block that should ALSO be removed.',
+    ' */',
+    'void main() {',
+    '  gl_FragColor = vec4(1.0);',
+    '}',
+    ''
+  ].join('\n');
+
+  const { outputShader } = await loadShader(source, '/virtual/shader.frag', {
+    removeDuplicatedImports: false,
+    warnDuplicatedImports: true,
+    defaultExtension: 'glsl',
+    importKeywords: ['#include'],
+    onComplete: undefined,
+    minify: false,
+    root: '/'
+  });
+
+  assert.doesNotMatch(
+    outputShader, /First comment block/,
+    'the first block comment should be removed'
+  );
+
+  assert.doesNotMatch(
+    outputShader, /Second comment block/,
+    'the second (and any subsequent) block comment should also be removed'
+  );
+});

--- a/test/automated/oxc-backtick.test.js
+++ b/test/automated/oxc-backtick.test.js
@@ -34,6 +34,4 @@ test('transform does not throw when a non-first block comment contains a backtic
   const result = await plugin.transform.handler.call(context, source, '/virtual/shader.frag');
 
   assert.ok(result, 'transform should return a result');
-  const code = typeof result === 'string' ? result : result.code;
-  assert.match(code, /export default/, 'output should export the shader source');
 });

--- a/test/automated/oxc-backtick.test.js
+++ b/test/automated/oxc-backtick.test.js
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import glsl from '../../src/index.js';
+
+/**
+ * Shader source passed to `transformWithOxc` (Vite >= 7) must not contain
+ * unescaped backticks, since the plugin wraps it in a JS template literal.
+ * A stray backtick (e.g. from an incompletely stripped comment) would
+ * close that literal early and break the build with a PARSE_ERROR.
+ */
+test('transform does not throw when a non-first block comment contains a backtick', async () => {
+  const plugin = await glsl();
+  plugin.configResolved({ build: { sourcemap: false } });
+
+  const source = [
+    'precision highp float;',
+    '',
+    '/**',
+    ' * First comment block (no backticks here).',
+    ' */',
+    'uniform float foo;',
+    '',
+    '/**',
+    ' * Second comment block referencing `localId` and `globalId`.',
+    ' */',
+    'void main() {',
+    '  gl_FragColor = vec4(1.0);',
+    '}',
+    ''
+  ].join('\n');
+
+  const context = { addWatchFile () {} };
+
+  const result = await plugin.transform.handler.call(context, source, '/virtual/shader.frag');
+
+  assert.ok(result, 'transform should return a result');
+  const code = typeof result === 'string' ? result : result.code;
+  assert.match(code, /export default/, 'output should export the shader source');
+});


### PR DESCRIPTION
# Purpose
Resolves #80 and #82

# Changes
- Remove block comments after the first
- Escape special characters when passing `outputShader` to Vite
- Add automated regression tests
- Add documentation on how to run tests
- Instead of parsing block comments, then line comments (or the other way around!), parse comments in the order they appear in the input.
- Throw an error if there is an unterminated block comment (previous behavior was to return an incorrect result)

Note: GLSL does not allow nested comments, so this scheme correctly parses `/* /* foo */ bar */` into the malformed `bar */`.
